### PR TITLE
Support composite Ecto.Type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ defmodule CreateAccount do
   use Commanded.Command,
       username: :string,
       email: :string,
-      age: :integer
+      age: {:integer, default: 0},
+      aliases: {{:array, :string}} # Composite Type requires extra brace to avoid being interprated as opts
 end
 
-iex> CreateAccount.new() 
+iex> CreateAccount.new()
 #Ecto.Changeset<action: nil, changes: %{}, errors: [], data: #CreateAccount<>, valid?: true>
 ```
 
@@ -54,7 +55,7 @@ defmodule CreateAccount do
   end
 end
 
-iex> CreateAccount.new() 
+iex> CreateAccount.new()
 #Ecto.Changeset<
   action: nil,
   changes: %{},
@@ -67,7 +68,7 @@ iex> CreateAccount.new()
   valid?: false
 >
 
-iex> changeset = CreateAccount.new(username: "chris", email: "chris@example.com", age: 5) 
+iex> changeset = CreateAccount.new(username: "chris", email: "chris@example.com", age: 5)
 #Ecto.Changeset<
   action: nil,
   changes: %{age: 5, email: "chris@example.com", username: "chris"},
@@ -149,7 +150,7 @@ iex> event = AccountCreated.new(cmd)
 
 You may have noticed that we provide a default version of `1`.
 
-You can change the version of an event at anytime. 
+You can change the version of an event at anytime.
 
 After doing so, you should define an upcast instance that knows how to transform older events into the latest version.
 

--- a/lib/commanded/command.ex
+++ b/lib/commanded/command.ex
@@ -6,18 +6,19 @@ defmodule Commanded.Command do
         use Commanded.Command,
           username: :string,
           email: :string,
-          age: :integer
+          age: :integer,
+          aliases: {{:array, :string}}
 
         def handle_validate(changeset) do
           changeset
-          |> validate_required([:username, :email, :age])
+          |> validate_required([:username, :email, :age, :aliases])
           |> validate_format(:email, ~r/@/)
           |> validate_number(:age, greater_than: 12)
         end
       end
 
-      iex> CreateAccount.new(username: "chris", email: "chris@example.com", age: 5)
-      #Ecto.Changeset<action: nil, changes: %{age: 5, email: "chris@example.com", username: "chris"}, errors: [age: {"must be greater than %{number}", [validation: :number, kind: :greater_than, number: 12]}], data: #CreateAccount<>, valid?: false>
+      iex> CreateAccount.new(username: "chris", email: "chris@example.com", age: 5, aliases: ["christopher", "kris"])
+      #Ecto.Changeset<action: nil, changes: %{age: 5, aliases: ["christopher", "kris"], email: "chris@example.com", username: "chris"}, errors: [age: {"must be greater than %{number}", [validation: :number, kind: :greater_than, number: 12]}], data: #CreateAccount<>, valid?: false>
   """
 
   @doc """

--- a/lib/commanded/command.ex
+++ b/lib/commanded/command.ex
@@ -35,6 +35,8 @@ defmodule Commanded.Command do
       @primary_key false
       embedded_schema do
         Enum.map(unquote(schema), fn
+          {name, {{_, _} = composite_type, opts}} -> field(name, field_type(composite_type), opts)
+          {name, {{_, _} = composite_type}} -> field(name, field_type(composite_type))
           {name, {type, opts}} -> field(name, field_type(type), opts)
           {name, type} -> field(name, field_type(type))
         end)
@@ -60,5 +62,8 @@ defmodule Commanded.Command do
   end
 
   def field_type(:binary_id), do: Ecto.UUID
+  def field_type(:array) do
+    raise "`:array` is not a valid Ecto.Type\nIf you are using a composite data type, wrap the type definition like this `{{:array, :string}}`"
+  end
   def field_type(type), do: type
 end

--- a/test/support/messages.ex
+++ b/test/support/messages.ex
@@ -9,7 +9,8 @@ defmodule CreateAccount do
   use Commanded.Command,
     username: :string,
     email: :string,
-    age: :integer
+    age: :integer,
+    aliases: {{:array, :string}}
 
   def handle_validate(changeset) do
     changeset


### PR DESCRIPTION
This fixes an issue where using Ecto's composite data types was not being handled in the `Commanded.Command` macro and was being split to consider the second value options.

## Solution

I wanted to maintain the current API in case others are using it, so the solution was to require an extra set of braces when using compound types.